### PR TITLE
Add translation support header for GEM Mailer plugin

### DIFF
--- a/gem-mailer.php
+++ b/gem-mailer.php
@@ -4,6 +4,8 @@
  * Description : Verzamel-plugin die losse mail-modules laadt (Reacties enz.).
  * Version     : 1.2
  * Author      : QuickDesign
+ * Text Domain: gem-mailer
+ * Domain Path: /languages
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Summary
- add Text Domain and Domain Path to GEM Mailer plugin header for WordPress localization
- create languages directory placeholder for future translation files

## Testing
- `php -l gem-mailer.php`

------
https://chatgpt.com/codex/tasks/task_e_68b177fb6d288333b76bb4c22484e8b4