### PR TITLE
Handle non-first taxonomy in new-topic mail dispatch

### DIFF
--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -33,9 +33,13 @@ function gem_get_option_int( string $key ): int {
 function gem_topic_to_thema( int $topic_id ): ?int {
         $taxes = get_post_taxonomies( $topic_id );
         if ( ! $taxes ) { return null; }
-        $terms = wp_get_post_terms( $topic_id, reset( $taxes ) );
-        if ( is_wp_error( $terms ) || empty( $terms ) ) { return null; }
-        return (int) $terms[0]->term_id;
+        foreach ( $taxes as $tax ) {
+                $terms = wp_get_post_terms( $topic_id, $tax );
+                if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+                        return (int) $terms[0]->term_id;
+                }
+        }
+        return null;
 }
 
 function gem_users_from_thema( int $thema_id, int $rel_tu ): array {


### PR DESCRIPTION
## Summary
- check all topic taxonomies to find the first assigned term

## Testing
- `php -l modules/new-topic-mail.php`


------
https://chatgpt.com/codex/tasks/task_e_68b182084da88333833caec5f006c204