### PR TITLE
Use correct post type slug for topic save hook

### DIFF
--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -197,9 +197,9 @@ add_action( 'gem_new_topic_mail', function ( ...$args ) {
 
 
 /* 2️⃣  BACK-END – publish/update (front-end nu óók toegestaan) */
-add_action( 'save_post_gem-onderwerpen', function ( $pid, $post ) {
+add_action( 'save_post_forums', function ( $pid, $post ) {
 
-	error_log( "GEM-MAIL new-topic: save_post_gem-onderwerpen for post {$pid}" );
+        error_log( "GEM-MAIL new-topic: save_post_forums for post {$pid}" );
 
 	if ( wp_is_post_autosave( $pid ) || wp_is_post_revision( $pid ) ) { return; }
 	if ( 'publish' !== $post->post_status ) { return; }


### PR DESCRIPTION
## Summary
- align `save_post` hook with JetEngine topic post type slug

## Testing
- `php -l modules/new-topic-mail.php`


------
https://chatgpt.com/codex/tasks/task_e_68b18209a8088333afaa699ae25d917a