### PR TITLE
feat: centralize new-topic logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 GEM Mailer is a WordPress plugin that powers email notifications for new topics and other events. The main plugin file `gem-mailer.php` lives at the repository root and loads individual modules from the `modules/` directory.
 
+## Logging
+
+The plugin uses PHP's `error_log()` function for diagnostics. You can redirect these logs to a specific file by setting a custom error log path:
+
+```php
+ini_set('error_log', '/path/to/gem-mailer.log');
+```
+
 ## Contributors
 
 - cfreer

--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -21,6 +21,12 @@
  * Cron     : gem_new_topic_retry        – één her-poging 10 s later
  */
 
+if ( ! function_exists( 'gem_log' ) ) {
+        function gem_log( string $msg ): void {
+                error_log( 'GEM-MAIL new-topic: ' . $msg );
+        }
+}
+
 if ( ! function_exists( 'gem_try_new_topic_mail' ) ) :   /* guard */
 
 /* ───────────── helpers ───────────── */
@@ -118,22 +124,22 @@ function gem_send_new_topic_bulk( array $uids, int $thema_id, int $topic_id, str
 
 function gem_try_new_topic_mail( int $topic_id ): void {
 
-	error_log( "GEM-MAIL new-topic: gem_try_new_topic_mail({$topic_id})" );
+        gem_log( "gem_try_new_topic_mail({$topic_id})" );
 
-	if ( ! $topic_id ) {
-		error_log( 'GEM-MAIL new-topic: aborted – topic_id is 0.' );
-		return;
-	}
+        if ( ! $topic_id ) {
+                gem_log( 'aborted – topic_id is 0.' );
+                return;
+        }
 
 	/* ─ throttle ─ */
 	$last = (int) get_post_meta( $topic_id, '_gem_new_topic_mail_sent', true );
-	if ( $last && ( time() - $last ) < 60 ) {
-		error_log( sprintf(
-			'GEM-MAIL new-topic: throttle – topic %d already mailed %d s ago.',
-			$topic_id, time() - $last
-		) );
-		return;
-	}
+        if ( $last && ( time() - $last ) < 60 ) {
+                gem_log( sprintf(
+                        'throttle – topic %d already mailed %d s ago.',
+                        $topic_id, time() - $last
+                ) );
+                return;
+        }
 
         /* ─ opties ─ */
         $rel_to   = gem_get_option_int( 'gem_mailer_settings_gem_thema_onderwerp_relation' );
@@ -142,23 +148,23 @@ function gem_try_new_topic_mail( int $topic_id ): void {
                 ?: '<p>Nieuw onderwerp: {{topic_title}}</p>';
 
         if ( ! $rel_to ) {
-                error_log( 'GEM-MAIL new-topic: missing rel_to option.' );
+                gem_log( 'missing rel_to option.' );
                 return;
         }
 
         if ( ! $rel_tu ) {
-                error_log( 'GEM-MAIL new-topic: missing rel_tu option.' );
+                gem_log( 'missing rel_tu option.' );
                 return;
         }
 
         /* ─ thema & ontvangers ─ */
         $thema_ids = gem_topic_to_themas( $topic_id, $rel_to );
         if ( ! $thema_ids ) {
-                error_log( "GEM-MAIL new-topic: no parent Thema found for topic {$topic_id} via rel_to {$rel_to}." );
+                gem_log( "no parent Thema found for topic {$topic_id} via rel_to {$rel_to}." );
                 return;
         }
 
-       error_log( "GEM-MAIL new-topic: Themas " . implode( ',', $thema_ids ) . " via rel_to {$rel_to}." );
+       gem_log( "Themas " . implode( ',', $thema_ids ) . " via rel_to {$rel_to}." );
 
        $sent = [];
        foreach ( $thema_ids as $thema_id ) {
@@ -179,13 +185,13 @@ function gem_try_new_topic_mail( int $topic_id ): void {
        }
 
         if ( ! $sent ) {
-                error_log( "GEM-MAIL new-topic: no recipients for topic {$topic_id}." );
+                gem_log( "no recipients for topic {$topic_id}." );
                 return;
         }
 
         update_post_meta( $topic_id, '_gem_new_topic_mail_sent', time() );
 
-        error_log( "GEM-MAIL new-topic: mail sent for topic {$topic_id} to " . implode( ',', $sent ) );
+        gem_log( "mail sent for topic {$topic_id} to " . implode( ',', $sent ) );
 }
 
 endif;  /* end guard */
@@ -196,7 +202,7 @@ endif;  /* end guard */
 /* 1️⃣  FRONT-END – JetForm “Call a Hook” */
 add_action( 'gem_new_topic_mail', function ( ...$args ) {
 
-	error_log( 'GEM-MAIL new-topic: gem_new_topic_mail hook fired. Args: ' . print_r( $args, true ) );
+        gem_log( 'gem_new_topic_mail hook fired. Args: ' . print_r( $args, true ) );
 
 	$topic_id = 0;
 
@@ -210,10 +216,10 @@ add_action( 'gem_new_topic_mail', function ( ...$args ) {
 		}
 	}
 
-	if ( ! $topic_id ) {
-		error_log( 'GEM-MAIL new-topic: abort – no topic_id extracted.' );
-		return;
-	}
+        if ( ! $topic_id ) {
+                gem_log( 'abort – no topic_id extracted.' );
+                return;
+        }
 
 	gem_try_new_topic_mail( $topic_id );
 
@@ -226,7 +232,7 @@ add_action( 'gem_new_topic_mail', function ( ...$args ) {
 /* 2️⃣  BACK-END – publish/update (front-end nu óók toegestaan) */
 add_action( 'save_post_forums', function ( $pid, $post ) {
 
-        error_log( "GEM-MAIL new-topic: save_post_forums for post {$pid}" );
+        gem_log( "save_post_forums for post {$pid}" );
 
 	if ( wp_is_post_autosave( $pid ) || wp_is_post_revision( $pid ) ) { return; }
 	if ( 'publish' !== $post->post_status ) { return; }


### PR DESCRIPTION
## Summary
- add gem_log helper for consistent new-topic mail logging
- replace direct error_log usage with gem_log
- document custom error log file configuration

## Testing
- `php -l modules/new-topic-mail.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1b639fdd08333a4d33f717b20247b