### PR TITLE
Log parent Thema IDs before returning first

### DIFF
--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -50,9 +50,25 @@ function gem_topic_to_themas( int $topic_id, int $rel_to ): array {
         return array_map( 'intval', $terms );
 }
 
+/**
+ * Resolve a topic to its primary Thema term ID.
+ *
+ * Collects all term IDs from the parent post and logs the full list before
+ * returning the first one. The return value may be expanded to an array in
+ * the future to support multiple themes.
+ */
+function gem_topic_to_thema( int $topic_id, int $rel_to ): ?int {
+       $thema_ids = gem_topic_to_themas( $topic_id, $rel_to );
+       if ( ! $thema_ids ) { return null; }
+
+       error_log( 'GEM-MAIL new-topic: parent Thema IDs ' . implode( ',', $thema_ids ) );
+
+       return $thema_ids[0];
+}
+
 function gem_users_from_thema( int $thema_id, int $rel_tu ): array {
-	global $wpdb;
-	if ( ! $rel_tu ) { return []; }
+        global $wpdb;
+        if ( ! $rel_tu ) { return []; }
 	return array_map( 'intval', $wpdb->get_col( $wpdb->prepare(
 		"SELECT child_object_id FROM {$wpdb->prefix}jet_rel_{$rel_tu}
 		 WHERE parent_object_id = %d",


### PR DESCRIPTION
## Summary
- Add helper gem_topic_to_thema that collects and logs all parent Thema term IDs before returning the first, preparing for future array returns

## Testing
- `php -l modules/new-topic-mail.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1b63e72e88333a0eca07d0b364db4