### PR TITLE
Add shared option helpers and admin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The plugin uses PHP's `error_log()` function for diagnostics. You can redirect t
 ini_set('error_log', '/path/to/gem-mailer.log');
 ```
 
+## Configuratie
+
+From WordPress 6.0 and up the plugin adds a read-only settings help page under **Settings → GEM Mailer**. The page lists every option key the modules rely on, including which JetEngine relation ID should be stored on each field (for example the relation between a Thema and its gebruikers). Use this overview to verify that the slugs in JetEngine Options Pages exactly match the expected option names.
+
 ## Contributors
 
 - cfreer

--- a/gem-mailer.php
+++ b/gem-mailer.php
@@ -23,6 +23,9 @@ define( 'GEM_MAILER_VER', '1.2' );
  *
  * Zet elke nieuwe module in /modules en require_once hier.
  */
+// Gemeenschappelijke helpers ------------------------------------------
+require_once GEM_MAILER_DIR . 'includes/options.php';
+
 // Modules laden --------------------------------------------------------
 require_once GEM_MAILER_DIR . 'modules/reactions-mail.php';   // Reactie-notificaties
 require_once GEM_MAILER_DIR . 'modules/jfb-hook.php';         // JetForm extra hook

--- a/includes/options.php
+++ b/includes/options.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Shared option constants and helper utilities for the GEM Mailer plugin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+        exit;
+}
+
+const GEM_MAILER_OPT_REL_THEMA_TOPIC   = 'gem_mailer_settings_gem_thema_onderwerp_relation';
+const GEM_MAILER_OPT_REL_THEMA_USER    = 'gem_mailer_settings_gem_thema_user_relation';
+const GEM_MAILER_OPT_TEMPLATE_TOPIC    = 'gem_mailer_settings_gem_nieuwe_onderwerp_in_thema_email';
+const GEM_MAILER_OPT_REL_TOPIC_REACTIE = 'gem_mailer_settings_gem_onderwerp_reactie_relation';
+const GEM_MAILER_OPT_REL_REACTIE_USER  = 'gem_mailer_settings_gem_reactie_relation';
+const GEM_MAILER_OPT_TEMPLATE_REACTIE  = 'gem_mailer_settings_reacties_email';
+const GEM_MAILER_OPT_REL_REPLY_REACTIE = 'gem_mailer_settings_gem_reactie-reactie_relation';
+const GEM_MAILER_OPT_TEMPLATE_REPLY    = 'gem_mailer_settings_reacties-reacties_email';
+
+/**
+ * Retrieve an integer option value while gracefully handling JetEngine array payloads.
+ */
+function gem_mailer_get_option_int( string $key ): int {
+        $raw = get_option( $key, 0 );
+        if ( is_array( $raw ) ) {
+                $raw = reset( $raw );
+        }
+        return (int) $raw;
+}
+
+/**
+ * Describe all configurable options so we can surface consistent help text in the admin UI.
+ */
+function gem_mailer_option_catalog(): array {
+        return [
+                GEM_MAILER_OPT_REL_THEMA_TOPIC   => [
+                        'label'       => __( 'Relatie: Thema → Onderwerp', 'gem-mailer' ),
+                        'description' => __( 'JetEngine relatie-ID waarmee een nieuw onderwerp aan zijn hoofdthema gekoppeld is. Parent: Thema (taxonomie of post), Child: Onderwerp (forums-post).', 'gem-mailer' ),
+                        'used_by'     => __( 'Modules “Nieuw onderwerp in thema” en de JetFormBuilder hook voor nieuwe onderwerpen.', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_REL_THEMA_USER    => [
+                        'label'       => __( 'Relatie: Thema → Gebruiker', 'gem-mailer' ),
+                        'description' => __( 'JetEngine relatie-ID die alle geabonneerde gebruikers bij een thema ophaalt. Parent: Thema, Child: Gebruiker.', 'gem-mailer' ),
+                        'used_by'     => __( 'Module “Nieuw onderwerp in thema” (bepaalt de ontvangerslijst).', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_TEMPLATE_TOPIC    => [
+                        'label'       => __( 'E-mailsjabloon: nieuw onderwerp', 'gem-mailer' ),
+                        'description' => __( 'HTML-sjabloon voor meldingen bij nieuwe onderwerpen. Beschikbare placeholders: {{recipient_name}}, {{thema_title}}, {{topic_title}}, {{topic_permalink}}, {{topic_excerpt}}, {{topic_author}}, {{site_name}}, {{site_url}}.', 'gem-mailer' ),
+                        'used_by'     => __( 'Module “Nieuw onderwerp in thema”.', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_REL_TOPIC_REACTIE => [
+                        'label'       => __( 'Relatie: Onderwerp → Reactie', 'gem-mailer' ),
+                        'description' => __( 'JetEngine relatie-ID die een reactie koppelt aan het onderliggende onderwerp. Parent: Onderwerp (forums-post), Child: Reactie (gem-reacties).', 'gem-mailer' ),
+                        'used_by'     => __( 'Modules “Reacties op onderwerpen” en “Reacties op reacties”, plus JetFormBuilder hooks voor reacties.', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_REL_REACTIE_USER  => [
+                        'label'       => __( 'Relatie: Reactie → Gebruiker', 'gem-mailer' ),
+                        'description' => __( 'Optionele JetEngine relatie-ID die extra volgers of betrokken gebruikers aan een reactie koppelt. Parent: Reactie, Child: Gebruiker.', 'gem-mailer' ),
+                        'used_by'     => __( 'Modules “Reacties op onderwerpen” en “Reacties op reacties”.', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_TEMPLATE_REACTIE  => [
+                        'label'       => __( 'E-mailsjabloon: reactie op onderwerp', 'gem-mailer' ),
+                        'description' => __( 'HTML-sjabloon voor notificaties wanneer iemand een reactie op een onderwerp plaatst. Beschikbare placeholders: {{recipient_name}}, {{reaction_author}}, {{reaction_excerpt}}, {{reaction_permalink}}, {{topic_title}}, {{topic_permalink}}, {{site_name}}, {{site_url}}.', 'gem-mailer' ),
+                        'used_by'     => __( 'Module “Reacties op onderwerpen”.', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_REL_REPLY_REACTIE => [
+                        'label'       => __( 'Relatie: Reactie → Reactie (reply)', 'gem-mailer' ),
+                        'description' => __( 'JetEngine relatie-ID voor de hiërarchie tussen reacties en hun replies. Parent: Hoofdreactie, Child: Reply (gem-reacties).', 'gem-mailer' ),
+                        'used_by'     => __( 'Module “Reacties op reacties” en JetFormBuilder hook voor replies.', 'gem-mailer' ),
+                ],
+                GEM_MAILER_OPT_TEMPLATE_REPLY    => [
+                        'label'       => __( 'E-mailsjabloon: reactie op reactie', 'gem-mailer' ),
+                        'description' => __( 'HTML-sjabloon voor reply-notificaties. Beschikbare placeholders: {{recipient_name}}, {{reply_author}}, {{reply_excerpt}}, {{reply_permalink}}, {{reaction_author}}, {{reaction_excerpt}}, {{topic_title}}, {{topic_permalink}}, {{site_name}}, {{site_url}}.', 'gem-mailer' ),
+                        'used_by'     => __( 'Module “Reacties op reacties”.', 'gem-mailer' ),
+                ],
+        ];
+}
+
+/**
+ * Register a read-only settings help page that lists all option keys and their purpose.
+ */
+function gem_mailer_register_settings_help(): void {
+        add_options_page(
+                __( 'GEM Mailer instellingen', 'gem-mailer' ),
+                __( 'GEM Mailer', 'gem-mailer' ),
+                'manage_options',
+                'gem-mailer-settings',
+                'gem_mailer_render_settings_help'
+        );
+}
+add_action( 'admin_menu', 'gem_mailer_register_settings_help' );
+
+/**
+ * Render the settings overview table.
+ */
+function gem_mailer_render_settings_help(): void {
+        if ( ! current_user_can( 'manage_options' ) ) {
+                return;
+        }
+
+        $catalog = gem_mailer_option_catalog();
+        ?>
+        <div class="wrap">
+                <h1><?php esc_html_e( 'GEM Mailer instellingenoverzicht', 'gem-mailer' ); ?></h1>
+                <p><?php esc_html_e( 'Onderstaande tabel toont alle option keys die de mailmodules gebruiken. Controleer of iedere JetEngine-relatie of sjabloon op de juiste sleutel is opgeslagen.', 'gem-mailer' ); ?></p>
+                <table class="widefat striped">
+                        <thead>
+                                <tr>
+                                        <th scope="col"><?php esc_html_e( 'Optiesleutel', 'gem-mailer' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Omschrijving', 'gem-mailer' ); ?></th>
+                                        <th scope="col"><?php esc_html_e( 'Gebruikt door', 'gem-mailer' ); ?></th>
+                                </tr>
+                        </thead>
+                        <tbody>
+                                <?php foreach ( $catalog as $key => $info ) : ?>
+                                        <tr>
+                                                <td><code><?php echo esc_html( $key ); ?></code></td>
+                                                <td>
+                                                        <strong><?php echo esc_html( $info['label'] ); ?></strong>
+                                                        <p class="description"><?php echo esc_html( $info['description'] ); ?></p>
+                                                </td>
+                                                <td><?php echo esc_html( $info['used_by'] ); ?></td>
+                                        </tr>
+                                <?php endforeach; ?>
+                        </tbody>
+                </table>
+        </div>
+        <?php
+}

--- a/modules/jfb-hook.php
+++ b/modules/jfb-hook.php
@@ -22,7 +22,7 @@ if ( ! function_exists( 'gem_jfb_notify_parent_author' ) ) :
 			return;
 		}
 
-		$rel_id = (int) get_option( 'gem_mailer_settings_gem_onderwerp_reactie_relation', 0 );
+                $rel_id = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
 		if ( ! $rel_id ) { return; }
 
 		global $wpdb;

--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -29,14 +29,6 @@ if ( ! function_exists( 'gem_log' ) ) {
 
 if ( ! function_exists( 'gem_try_new_topic_mail' ) ) :   /* guard */
 
-/* ───────────── helpers ───────────── */
-
-function gem_get_option_int( string $key ): int {
-	$raw = get_option( $key, 0 );
-	if ( is_array( $raw ) ) { $raw = reset( $raw ); }
-	return (int) $raw;
-}
-
 function gem_topic_to_themas( int $topic_id, int $rel_to ): array {
         global $wpdb;
         if ( ! $rel_to ) { return []; }
@@ -171,9 +163,9 @@ function gem_try_new_topic_mail( int $topic_id ): void {
         }
 
         /* ─ opties ─ */
-        $rel_to   = gem_get_option_int( 'gem_mailer_settings_gem_thema_onderwerp_relation' );
-        $rel_tu   = gem_get_option_int( 'gem_mailer_settings_gem_thema_user_relation' );
-       $template = get_option( 'gem_mailer_settings_gem_nieuwe_onderwerp_in_thema_email', '' )
+        $rel_to   = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_THEMA_TOPIC );
+        $rel_tu   = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_THEMA_USER );
+       $template = get_option( GEM_MAILER_OPT_TEMPLATE_TOPIC, '' )
                 ?: '<p>Nieuw onderwerp: {{topic_title}}</p>';
 
         if ( ! $rel_to ) {

--- a/modules/reactions-mail.php
+++ b/modules/reactions-mail.php
@@ -76,9 +76,9 @@ if ( ! function_exists( 'gem_notify_mail' ) ) :
 			return;
 		}
 
-		$rel_post_post = (int) get_option( 'gem_mailer_settings_gem_onderwerp_reactie_relation', 0 );
-		$rel_post_user = (int) get_option( 'gem_mailer_settings_gem_reactie_relation', 0 );
-		$template      = get_option( 'gem_mailer_settings_reacties_email', '' )
+                $rel_post_post = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
+                $rel_post_user = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REACTIE_USER );
+                $template      = get_option( GEM_MAILER_OPT_TEMPLATE_REACTIE, '' )
 			?: '<p>Nieuwe reactie op "{{post_title}}".</p>';
 
 		if ( ! $rel_post_post ) {
@@ -145,7 +145,7 @@ add_action(
 	'jet-engine/relation/after-add-child',
 	function ( $relation, $parent_id, $child_id ) {
 
-		$config = (int) get_option( 'gem_mailer_settings_gem_onderwerp_reactie_relation', 0 );
+                $config = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
 		if ( intval( $relation->id ) !== $config ) {
 			return;
 		}

--- a/modules/replies-mail.php
+++ b/modules/replies-mail.php
@@ -126,10 +126,10 @@ if ( ! function_exists( 'gem_send_reply_mail' ) ) :
 		}
 
 		/* opties -------------------------------------------------------- */
-		$rel_rt  = (int) get_option( 'gem_mailer_settings_gem_onderwerp_reactie_relation', 0 );
-		$rel_rr  = (int) get_option( 'gem_mailer_settings_gem_reactie-reactie_relation', 0 );
-		$rel_ru  = (int) get_option( 'gem_mailer_settings_gem_reactie_relation', 0 );
-		$template = get_option( 'gem_mailer_settings_reacties-reacties_email', '' )
+		$rel_rt  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
+		$rel_rr  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REPLY_REACTIE );
+		$rel_ru  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REACTIE_USER );
+		$template = get_option( GEM_MAILER_OPT_TEMPLATE_REPLY, '' )
 			?: '<p>Er is een nieuwe reactie in “{{post_title}}”.</p>';
 
 		if ( ! $rel_rr || ! $rel_rt ) {
@@ -187,7 +187,7 @@ add_action( 'gem_reply_retry', 'gem_try_reply_mail' );
 
 /* --------- relation/after-add-child ---------------------------------- */
 add_action( 'jet-engine/relation/after-add-child', function ( $rel, $parent_id, $child_id ) {
-	if ( intval( $rel->id ) === (int) get_option( 'gem_mailer_settings_gem_reactie-reactie_relation', 0 ) ) {
+	if ( intval( $rel->id ) === gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REPLY_REACTIE ) ) {
 		gem_try_reply_mail( $child_id );     // child = nieuwe reply
 	}
 }, 10, 3 );


### PR DESCRIPTION
## Summary
- add shared option constants, helper functions, and a read-only settings overview under **Settings → GEM Mailer**
- require the shared helpers before loading the mail modules and update README with configuration guidance
- update all mail modules and JetFormBuilder hooks to use the shared option accessors instead of hardcoded option keys

## Testing
- php -l includes/options.php
- php -l modules/new-topic-mail.php
- php -l modules/reactions-mail.php
- php -l modules/replies-mail.php
- php -l modules/jfb-hook.php

------
https://chatgpt.com/codex/tasks/task_e_68cc1e9cad348333a951352ef6b09764