### PR TITLE
Ensure new topic mail module loads options helper

### DIFF
--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -21,6 +21,10 @@
  * Cron     : gem_new_topic_retry        – één her-poging 10 s later
  */
 
+if ( ! function_exists( 'gem_mailer_get_option_int' ) ) {
+        require_once __DIR__ . '/../includes/options.php';
+}
+
 if ( ! function_exists( 'gem_log' ) ) {
         function gem_log( string $msg ): void {
                 error_log( 'GEM-MAIL new-topic: ' . $msg );


### PR DESCRIPTION
## Summary
- add a conditional include for the options helper so the module can resolve gem_mailer_get_option_int when loaded on its own

## Testing
- php -l modules/new-topic-mail.php
- ./vendor/bin/phpunit -c phpunit.xml.dist *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2597f5c88333940148136b06a58f