### PR TITLE
Support JetEngine option aliases in mailer helpers

### DIFF
--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -21,6 +21,10 @@
  * Cron     : gem_new_topic_retry        – één her-poging 10 s later
  */
 
+if ( ! function_exists( 'gem_mailer_get_option_int' ) ) {
+        require_once __DIR__ . '/../includes/options.php';
+}
+
 if ( ! function_exists( 'gem_log' ) ) {
         function gem_log( string $msg ): void {
                 error_log( 'GEM-MAIL new-topic: ' . $msg );
@@ -165,7 +169,7 @@ function gem_try_new_topic_mail( int $topic_id ): void {
         /* ─ opties ─ */
         $rel_to   = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_THEMA_TOPIC );
         $rel_tu   = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_THEMA_USER );
-       $template = get_option( GEM_MAILER_OPT_TEMPLATE_TOPIC, '' )
+        $template = gem_mailer_get_option( GEM_MAILER_OPT_TEMPLATE_TOPIC, '' )
                 ?: '<p>Nieuw onderwerp: {{topic_title}}</p>';
 
         if ( ! $rel_to ) {

--- a/modules/reactions-mail.php
+++ b/modules/reactions-mail.php
@@ -78,8 +78,8 @@ if ( ! function_exists( 'gem_notify_mail' ) ) :
 
                 $rel_post_post = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
                 $rel_post_user = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REACTIE_USER );
-                $template      = get_option( GEM_MAILER_OPT_TEMPLATE_REACTIE, '' )
-			?: '<p>Nieuwe reactie op "{{post_title}}".</p>';
+                $template      = gem_mailer_get_option( GEM_MAILER_OPT_TEMPLATE_REACTIE, '' )
+                        ?: '<p>Nieuwe reactie op "{{post_title}}".</p>';
 
 		if ( ! $rel_post_post ) {
 			error_log( 'GEM-MAIL: rel_post_post optie ontbreekt.' );

--- a/modules/replies-mail.php
+++ b/modules/replies-mail.php
@@ -126,11 +126,11 @@ if ( ! function_exists( 'gem_send_reply_mail' ) ) :
 		}
 
 		/* opties -------------------------------------------------------- */
-		$rel_rt  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
-		$rel_rr  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REPLY_REACTIE );
-		$rel_ru  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REACTIE_USER );
-		$template = get_option( GEM_MAILER_OPT_TEMPLATE_REPLY, '' )
-			?: '<p>Er is een nieuwe reactie in “{{post_title}}”.</p>';
+                $rel_rt  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
+                $rel_rr  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REPLY_REACTIE );
+                $rel_ru  = gem_mailer_get_option_int( GEM_MAILER_OPT_REL_REACTIE_USER );
+                $template = gem_mailer_get_option( GEM_MAILER_OPT_TEMPLATE_REPLY, '' )
+                        ?: '<p>Er is een nieuwe reactie in “{{post_title}}”.</p>';
 
 		if ( ! $rel_rr || ! $rel_rt ) {
 			error_log( sprintf(

--- a/tests/OptionsHelperTest.php
+++ b/tests/OptionsHelperTest.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Tests for option helper fallbacks.
+ */
+class OptionsHelperTest extends WP_UnitTestCase {
+
+    public function setUp(): void {
+        parent::setUp();
+        delete_option( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
+        delete_option( 'gem_mailer_settings_onderwerpen-gem-cpt' );
+        delete_option( GEM_MAILER_OPT_TEMPLATE_REACTIE );
+    }
+
+    public function test_prefers_canonical_option_when_present(): void {
+        update_option( GEM_MAILER_OPT_REL_TOPIC_REACTIE, 21 );
+        update_option( 'gem_mailer_settings_onderwerpen-gem-cpt', 42 );
+
+        $this->assertSame( 21, gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE ) );
+    }
+
+    public function test_falls_back_to_alias_when_canonical_missing(): void {
+        delete_option( GEM_MAILER_OPT_REL_TOPIC_REACTIE );
+        update_option( 'gem_mailer_settings_onderwerpen-gem-cpt', 84 );
+
+        $this->assertSame( 84, gem_mailer_get_option_int( GEM_MAILER_OPT_REL_TOPIC_REACTIE ) );
+    }
+
+    public function test_string_helper_uses_resolved_option_key(): void {
+        delete_option( GEM_MAILER_OPT_TEMPLATE_REACTIE );
+        $expected = '<p>Hallo wereld</p>';
+        update_option( GEM_MAILER_OPT_TEMPLATE_REACTIE, $expected );
+
+        $this->assertSame( $expected, gem_mailer_get_option( GEM_MAILER_OPT_TEMPLATE_REACTIE, '' ) );
+    }
+}


### PR DESCRIPTION
## Summary
- add alias-aware option helpers so JetEngine option slugs like gem_mailer_settings_onderwerpen-gem-cpt resolve correctly
- expose the resolved key (and canonical alias note) on the settings overview page
- update mail modules to use the shared option helper and cover the behaviour with unit tests

## Testing
- php -l includes/options.php
- php -l modules/new-topic-mail.php
- php -l modules/reactions-mail.php
- php -l modules/replies-mail.php
- php -l tests/OptionsHelperTest.php
- ./vendor/bin/phpunit -c phpunit.xml.dist *(fails: Could not find /tmp/wordpress-tests-lib/includes/functions.php)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2597f5c88333940148136b06a58f