### PR TITLE
Restore module mailers with JetEngine option help

### DIFF
--- a/modules/jfb-hook.php
+++ b/modules/jfb-hook.php
@@ -9,6 +9,10 @@
  * Post Submit Actions → “Call Hook”.
  */
 
+if ( ! function_exists( 'gem_mailer_get_option_int' ) ) {
+        require_once __DIR__ . '/../includes/options.php';
+}
+
 /* ============================================================
  * 1 ▸ Reactie op een onderwerp
  * ========================================================== */

--- a/modules/new-topic-mail.php
+++ b/modules/new-topic-mail.php
@@ -21,6 +21,10 @@
  * Cron     : gem_new_topic_retry        – één her-poging 10 s later
  */
 
+if ( ! function_exists( 'gem_mailer_get_option_int' ) ) {
+        require_once __DIR__ . '/../includes/options.php';
+}
+
 if ( ! function_exists( 'gem_log' ) ) {
         function gem_log( string $msg ): void {
                 error_log( 'GEM-MAIL new-topic: ' . $msg );

--- a/modules/reactions-mail.php
+++ b/modules/reactions-mail.php
@@ -5,6 +5,10 @@
  *                maar NIET de auteur van de actuele reactie.
  */
 
+if ( ! function_exists( 'gem_mailer_get_option_int' ) ) {
+        require_once __DIR__ . '/../includes/options.php';
+}
+
 if ( ! function_exists( 'gem_notify_mail' ) ) :
 
 	/* -------------------- helpers -------------------- */

--- a/modules/replies-mail.php
+++ b/modules/replies-mail.php
@@ -8,6 +8,10 @@
  * Auteur  : GEM-Mailer
  */
 
+if ( ! function_exists( 'gem_mailer_get_option_int' ) ) {
+        require_once __DIR__ . '/../includes/options.php';
+}
+
 if ( ! function_exists( 'gem_send_reply_mail' ) ) :
 
 	/* ------------------------------------------------ helpers ---------- */


### PR DESCRIPTION
## Summary
- restore the module-based GEM Mailer implementation so the option keys, admin help table, and JetEngine integrations match the fields available in WordPress
- add conditional includes to every mailer module so the shared option helper is available when modules are loaded directly

## Testing
- php -l includes/options.php
- php -l modules/new-topic-mail.php
- php -l modules/reactions-mail.php
- php -l modules/replies-mail.php
- php -l modules/jfb-hook.php

------
https://chatgpt.com/codex/tasks/task_e_68dd2597f5c88333940148136b06a58f