### PR TITLE
Add CPT validation to new topic mailer

### DIFF
--- a/includes/Admin/TestMailer.php
+++ b/includes/Admin/TestMailer.php
@@ -102,7 +102,7 @@ class TestMailer {
                     'topic_excerpt' => __( 'Dit is een voorbeeldtekst voor een nieuw forumonderwerp.', 'gem-mailer' ),
                     'topic_author'  => __( 'Forumtester', 'gem-mailer' ),
                     'post_title'    => __( 'Voorbeeld onderwerp', 'gem-mailer' ),
-                    'post_permalink'=> home_url( '/forum/onderwerpen/voorbeeld' ),
+                    'post_permalink' => home_url( '/forum/onderwerpen/voorbeeld' ),
                     'site_name'     => get_bloginfo( 'name' ),
                     'site_url'      => home_url(),
                     'reply_author'  => '',


### PR DESCRIPTION
## Summary
- log and guard new topic scheduling when the post type is not allowed
- stop processing queued events for disallowed post types using a shared helper
- tidy the admin test mailer sample context formatting

## Testing
- php -l includes/Mailers/NewTopicMailer.php
- php -l includes/Admin/TestMailer.php

------
https://chatgpt.com/codex/tasks/task_e_690b43fce6b883338d84b1c61335cfda